### PR TITLE
negativ max for 'Negative' scenario

### DIFF
--- a/GyverBraid/main.js
+++ b/GyverBraid/main.js
@@ -132,6 +132,8 @@ function tracer() {
         if (dst > amount / 2) dst = amount - dst;
         dst = dst / amount * 360;
         if (dst < ui_get("Offset")) continue;
+
+        if ( i >= abs(node - (amount / 4) / 2 ) && i <= abs(node + (amount / 4) / 2 ) ) continue;
       }
 
       if (ui_get("Overlaps") > 0 && overlaps[i] + 1 > ui_get("Overlaps")) continue;

--- a/GyverBraid/main.js
+++ b/GyverBraid/main.js
@@ -17,7 +17,7 @@ let cv = [
 let ui;
 let img = null;
 let nodes = [];
-let overlaps = []
+let overlaps = [];
 let length;
 let density = 1;
 
@@ -118,7 +118,7 @@ function tracer() {
   setStatus("Running. Lines: " + count);
   let amount = ui_get("Node Amount");
   for (let i = 0; i < 10; i++) {
-    let max = 0;
+    let max = -10000000000;
     best = -1;
 
     loadPixels();


### PR DESCRIPTION
Для сценария с негативными значениями нужно учитывать что быстро наступает момент когда выбор линии происходит только из отрицательных значений. Поэтому инициировать max нужно с отрицательного числа.